### PR TITLE
Begun work on separation of main functionality and the functionality that uses the providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,11 @@ lettre_email = "0.9.2"
 hostname = "0.1"
 log4rs = "0.8"
 ipnet = "2.0"
+
+[[bin]]
+name = "ssh-notify"
+path = "src/main.rs"
+
+[[bin]]
+name = "ssh-notify-agent"
+path = "src/agent-bin.rs"

--- a/src/agent-bin.rs
+++ b/src/agent-bin.rs
@@ -1,0 +1,44 @@
+extern crate pretty_env_logger;
+extern crate log;
+extern crate toml;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate reqwest;
+extern crate lettre;
+extern crate lettre_email;
+extern crate hostname;
+extern crate ipnet;
+#[macro_use]
+extern crate log4rs;
+
+mod config;
+mod model;
+pub mod agent;
+
+use std::env::{var};
+
+fn main() {
+    let conf = config::config();
+    let mut vars = get_pam_vars();
+
+    if let Some(agents) = conf.agents {
+        for ag in agents {
+            match ag {
+                _ => {
+                    ag.send(vars.clone()).unwrap();
+                }
+            }
+        }
+    }
+}
+
+fn get_pam_vars() -> model::Vars {
+    let user = var("PAM_USER").expect("PAM ENV(PAM_USER) not found");
+    let rhost = var("PAM_RHOST").expect("PAM ENV(PAM_RHOST) not found");
+    let pamtype = var("PAM_TYPE").expect("PAM ENV(PAM_TYPE) not found");
+    let hostname_v = hostname::get_hostname().unwrap();
+    let is_whitelisted : bool = false;
+
+    model::Vars {user, r_host: rhost, hostname: hostname_v, pam_type: pamtype, is_whitelisted}
+}


### PR DESCRIPTION
This is done in order to be able to run the provider code as a child process, hopefully avoiding locking up/slowing down the SSH login process due to external factors(slow HTTP requests, SMTP, etc.)